### PR TITLE
Fix for link tag's type attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,9 @@
 	<meta http-equiv="Content-Style-Type" content="text/styles" />
 	<meta http-equiv="Content-Script-Type" content="text/javascript" />
 	<title>exValidationサンプル</title>
-	<link type="text/styles" rel="stylesheet" href="styles/style.css" />
-	<link type="text/styles" rel="stylesheet" href="skin/selectable/style.css" />
-	<link type="text/styles" rel="stylesheet" href="styles/exvalidation.css" />
+	<link type="text/css" rel="stylesheet" href="styles/style.css" />
+	<link type="text/css" rel="stylesheet" href="skin/selectable/style.css" />
+	<link type="text/css" rel="stylesheet" href="styles/exvalidation.css" />
 	<script>
 	  var _gaq = _gaq || [];
 	  _gaq.push(['_setAccount', 'UA-4011945-3']);

--- a/index2.html
+++ b/index2.html
@@ -5,9 +5,9 @@
 	<meta http-equiv="Content-Style-Type" content="text/styles" />
 	<meta http-equiv="Content-Script-Type" content="text/javascript" />
 	<title>exValidationサンプル 2</title>
-	<link type="text/styles" rel="stylesheet" href="styles/style.css" />
-	<link type="text/styles" rel="stylesheet" href="skin/selectable/style.css" />
-	<link type="text/styles" rel="stylesheet" href="styles/exvalidation.css" />
+	<link type="text/css" rel="stylesheet" href="styles/style.css" />
+	<link type="text/css" rel="stylesheet" href="skin/selectable/style.css" />
+	<link type="text/css" rel="stylesheet" href="styles/exvalidation.css" />
 	<script>
 	  var _gaq = _gaq || [];
 	  _gaq.push(['_setAccount', 'UA-4011945-3']);

--- a/index3.html
+++ b/index3.html
@@ -5,9 +5,9 @@
 	<meta http-equiv="Content-Style-Type" content="text/styles" />
 	<meta http-equiv="Content-Script-Type" content="text/javascript" />
 	<title>exValidationサンプル</title>
-	<link type="text/styles" rel="stylesheet" href="styles/style.css" />
-	<link type="text/styles" rel="stylesheet" href="skin/selectable/style.css" />
-	<link type="text/styles" rel="stylesheet" href="styles/exvalidation.css" />
+	<link type="text/css" rel="stylesheet" href="styles/style.css" />
+	<link type="text/css" rel="stylesheet" href="skin/selectable/style.css" />
+	<link type="text/css" rel="stylesheet" href="styles/exvalidation.css" />
 	<script>
 	  var _gaq = _gaq || [];
 	  _gaq.push(['_setAccount', 'UA-4011945-3']);

--- a/index4.html
+++ b/index4.html
@@ -5,9 +5,9 @@
 	<meta http-equiv="Content-Style-Type" content="text/styles" />
 	<meta http-equiv="Content-Script-Type" content="text/javascript" />
 	<title>exValidationサンプル</title>
-	<link type="text/styles" rel="stylesheet" href="styles/style.css" />
-	<link type="text/styles" rel="stylesheet" href="skin/selectable/style.css" />
-	<link type="text/styles" rel="stylesheet" href="styles/exvalidation.css" />
+	<link type="text/css" rel="stylesheet" href="styles/style.css" />
+	<link type="text/css" rel="stylesheet" href="skin/selectable/style.css" />
+	<link type="text/css" rel="stylesheet" href="styles/exvalidation.css" />
 	<script>
 	  var _gaq = _gaq || [];
 	  _gaq.push(['_setAccount', 'UA-4011945-3']);

--- a/index5.html
+++ b/index5.html
@@ -5,9 +5,9 @@
 	<meta http-equiv="Content-Style-Type" content="text/styles" />
 	<meta http-equiv="Content-Script-Type" content="text/javascript" />
 	<title>exValidationサンプル</title>
-	<link type="text/styles" rel="stylesheet" href="styles/style.css" />
-	<link type="text/styles" rel="stylesheet" href="skin/selectable/style.css" />
-	<link type="text/styles" rel="stylesheet" href="styles/exvalidation.css" />
+	<link type="text/css" rel="stylesheet" href="styles/style.css" />
+	<link type="text/css" rel="stylesheet" href="skin/selectable/style.css" />
+	<link type="text/css" rel="stylesheet" href="styles/exvalidation.css" />
 	<script>
 	  var _gaq = _gaq || [];
 	  _gaq.push(['_setAccount', 'UA-4011945-3']);

--- a/index6.html
+++ b/index6.html
@@ -5,9 +5,9 @@
 	<meta http-equiv="Content-Style-Type" content="text/styles" />
 	<meta http-equiv="Content-Script-Type" content="text/javascript" />
 	<title>exValidationサンプル 2</title>
-	<link type="text/styles" rel="stylesheet" href="styles/style.css" />
-	<link type="text/styles" rel="stylesheet" href="skin/selectable/style.css" />
-	<link type="text/styles" rel="stylesheet" href="styles/exvalidation.css" />
+	<link type="text/css" rel="stylesheet" href="styles/style.css" />
+	<link type="text/css" rel="stylesheet" href="skin/selectable/style.css" />
+	<link type="text/css" rel="stylesheet" href="styles/exvalidation.css" />
 	<script>
 	  var _gaq = _gaq || [];
 	  _gaq.push(['_setAccount', 'UA-4011945-3']);

--- a/index7.html
+++ b/index7.html
@@ -5,9 +5,9 @@
 	<meta http-equiv="Content-Style-Type" content="text/styles" />
 	<meta http-equiv="Content-Script-Type" content="text/javascript" />
 	<title>exValidationサンプル</title>
-	<link type="text/styles" rel="stylesheet" href="styles/style.css" />
-	<link type="text/styles" rel="stylesheet" href="skin/selectable/style.css" />
-	<link type="text/styles" rel="stylesheet" href="styles/exvalidation.css" />
+	<link type="text/css" rel="stylesheet" href="styles/style.css" />
+	<link type="text/css" rel="stylesheet" href="skin/selectable/style.css" />
+	<link type="text/css" rel="stylesheet" href="styles/exvalidation.css" />
 	<script>
 	  var _gaq = _gaq || [];
 	  _gaq.push(['_setAccount', 'UA-4011945-3']);

--- a/index8.html
+++ b/index8.html
@@ -5,9 +5,9 @@
 	<meta http-equiv="Content-Style-Type" content="text/styles" />
 	<meta http-equiv="Content-Script-Type" content="text/javascript" />
 	<title>exValidationサンプル</title>
-	<link type="text/styles" rel="stylesheet" href="styles/style.css" />
-	<link type="text/styles" rel="stylesheet" href="skin/selectable/style.css" />
-	<link type="text/styles" rel="stylesheet" href="styles/exvalidation.css" />
+	<link type="text/css" rel="stylesheet" href="styles/style.css" />
+	<link type="text/css" rel="stylesheet" href="skin/selectable/style.css" />
+	<link type="text/css" rel="stylesheet" href="styles/exvalidation.css" />
 	<script>
 	  var _gaq = _gaq || [];
 	  _gaq.push(['_setAccount', 'UA-4011945-3']);


### PR DESCRIPTION
サンプル HTML の link タグが type="text/styles" となっており、Firefox 等のブラウザでスタイルが効かなくなってたので直しますた。
